### PR TITLE
Added degitx go import meta tag

### DIFF
--- a/degitx.html
+++ b/degitx.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- allows using `import "cqfn.org/degitx"` in go modules -->
+    <meta name="go-import" content="cqfn.org/degitx git https://github.com/cqfn/degitx"/>
+  </head>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,6 @@
     <meta name="description" content="Small experimental software projects helping software engineers increase the quality of code"/>
     <meta name="keywords" content="code quality"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <!-- allows using `import "cqfn.org/degitx"` in go modules -->
-    <meta name="go-import" content="cqfn.org/degitx mod https://github.com/cqfn/degitx"/>
     <link rel="shortcut icon" href="logo.png"/>
     <link href='main.css' rel='stylesheet'/>
   </head>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta name="description" content="Small experimental software projects helping software engineers increase the quality of code"/>
     <meta name="keywords" content="code quality"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <!-- allows using `import "cqfn.org/degitx"` in go modules -->
+    <meta name="go-import" content="cqfn.org/degitx mod https://github.com/cqfn/degitx"/>
     <link rel="shortcut icon" href="logo.png"/>
     <link href='main.css' rel='stylesheet'/>
   </head>


### PR DESCRIPTION
Added `<meta>` tag to allow go module imports via `cqfn.org/degitx` package prefix, see https://golang.org/cmd/go/#hdr-Remote_import_paths